### PR TITLE
feat(CBP-46173): wire edge-redaction suppress-logs into code_scan_edge

### DIFF
--- a/.cloudbees/scanners/code_scan_edge.yaml
+++ b/.cloudbees/scanners/code_scan_edge.yaml
@@ -16,7 +16,13 @@ jobs:
       # to code-scanner steps so their stdout/stderr (which can quote matched source)
       # is drained but never uploaded to the cloud (CBP-46173). The value comes from
       # the org-scoped property edgeRedactionSuppressCodeScannerLogs.
-      EDGE_REDACTION_SUPPRESS_CODE_SCANNER_LOGS: ${{ vars.edgeRedactionSuppressCodeScannerLogs }}
+      #
+      # Index access (vars['...']) is used, NOT dot access (vars.x): an undefined
+      # workflow var read via dot access is a HARD ERROR that fails job-env validation
+      # at transform time, which would break every edge scan for orgs that haven't set
+      # the property. Index access returns empty for a missing key, and `|| 'false'`
+      # defaults it — so an unset property safely resolves to "false" (suppression off).
+      EDGE_REDACTION_SUPPRESS_CODE_SCANNER_LOGS: ${{ vars['edgeRedactionSuppressCodeScannerLogs'] || 'false' }}
     steps:
       - name: Initiate execution plan
         uses: https://github.com/cloudbees-io/asset-chain-utils/start-chain@v1

--- a/.cloudbees/scanners/code_scan_edge.yaml
+++ b/.cloudbees/scanners/code_scan_edge.yaml
@@ -86,11 +86,8 @@ jobs:
           RUN_ID: ${{ cloudbees.run_id }}
           JOB_ID: ${{ job.id }}
           STEP_ID: ${{ step.internal.id }}
-          # Edge redaction (CBP-46173): when the org enables it, the engine drains
-          # this code scanner's stdout/stderr (which can quote matched source) instead
-          # of uploading it to the cloud. Set only on code/SAST scanner steps; SCA
-          # steps below omit it. Index access + default so an unset org var resolves
-          # to "false" (a dot-access undefined var would fail the whole edge scan).
+          # Edge redaction (CBP-46173): suppress this code scanner's logs (can quote
+          # source). Code/SAST steps only; index+default so an unset var → "false".
           CLOUDBEES_SUPPRESS_LOGS: ${{ vars['edgeRedactionSuppressCodeScannerLogs'] || 'false' }}
         continue-on-error: true
         run: /app/plugin-scc-scanner -mode single

--- a/.cloudbees/scanners/code_scan_edge.yaml
+++ b/.cloudbees/scanners/code_scan_edge.yaml
@@ -11,18 +11,6 @@ jobs:
     # condition. Cloud scans (code_scan.yaml) omit this and keep using /reserved/v1.
     env:
       EDGE_SCAN_RUN: "true"
-      # Carries the org's edge-redaction decision (CBP-46176) to transform time. The
-      # edge transformer reads this job env and, when "true", appends --suppress-logs
-      # to code-scanner steps so their stdout/stderr (which can quote matched source)
-      # is drained but never uploaded to the cloud (CBP-46173). The value comes from
-      # the org-scoped property edgeRedactionSuppressCodeScannerLogs.
-      #
-      # Index access (vars['...']) is used, NOT dot access (vars.x): an undefined
-      # workflow var read via dot access is a HARD ERROR that fails job-env validation
-      # at transform time, which would break every edge scan for orgs that haven't set
-      # the property. Index access returns empty for a missing key, and `|| 'false'`
-      # defaults it — so an unset property safely resolves to "false" (suppression off).
-      EDGE_REDACTION_SUPPRESS_CODE_SCANNER_LOGS: ${{ vars['edgeRedactionSuppressCodeScannerLogs'] || 'false' }}
     steps:
       - name: Initiate execution plan
         uses: https://github.com/cloudbees-io/asset-chain-utils/start-chain@v1
@@ -98,6 +86,12 @@ jobs:
           RUN_ID: ${{ cloudbees.run_id }}
           JOB_ID: ${{ job.id }}
           STEP_ID: ${{ step.internal.id }}
+          # Edge redaction (CBP-46173): when the org enables it, the engine drains
+          # this code scanner's stdout/stderr (which can quote matched source) instead
+          # of uploading it to the cloud. Set only on code/SAST scanner steps; SCA
+          # steps below omit it. Index access + default so an unset org var resolves
+          # to "false" (a dot-access undefined var would fail the whole edge scan).
+          CLOUDBEES_SUPPRESS_LOGS: ${{ vars['edgeRedactionSuppressCodeScannerLogs'] || 'false' }}
         continue-on-error: true
         run: /app/plugin-scc-scanner -mode single
 
@@ -108,6 +102,7 @@ jobs:
           RUN_ID: ${{ cloudbees.run_id }}
           JOB_ID: ${{ job.id }}
           STEP_ID: ${{ step.internal.id }}
+          CLOUDBEES_SUPPRESS_LOGS: ${{ vars['edgeRedactionSuppressCodeScannerLogs'] || 'false' }}
         continue-on-error: true
         run: /app/plugin-gosec-scanner -mode single
 
@@ -118,6 +113,7 @@ jobs:
           RUN_ID: ${{ cloudbees.run_id }}
           JOB_ID: ${{ job.id }}
           STEP_ID: ${{ step.internal.id }}
+          CLOUDBEES_SUPPRESS_LOGS: ${{ vars['edgeRedactionSuppressCodeScannerLogs'] || 'false' }}
         continue-on-error: true
         run: /app/plugin-njsscan-scanner -mode single
 
@@ -129,6 +125,7 @@ jobs:
           RUN_ID: ${{ cloudbees.run_id }}
           JOB_ID: ${{ job.id }}
           STEP_ID: ${{ step.internal.id }}
+          CLOUDBEES_SUPPRESS_LOGS: ${{ vars['edgeRedactionSuppressCodeScannerLogs'] || 'false' }}
         run: /app/plugin-gitleaks-scanner -mode single
 
       - name: BlackDuck Scanner
@@ -160,6 +157,7 @@ jobs:
           RUN_ID: ${{ cloudbees.run_id }}
           JOB_ID: ${{ job.id }}
           STEP_ID: ${{ step.internal.id }}
+          CLOUDBEES_SUPPRESS_LOGS: ${{ vars['edgeRedactionSuppressCodeScannerLogs'] || 'false' }}
         continue-on-error: true
         run: /app/plugin-checkov -mode single
 
@@ -171,6 +169,7 @@ jobs:
           RUN_ID: ${{ cloudbees.run_id }}
           JOB_ID: ${{ job.id }}
           STEP_ID: ${{ step.internal.id }}
+          CLOUDBEES_SUPPRESS_LOGS: ${{ vars['edgeRedactionSuppressCodeScannerLogs'] || 'false' }}
         continue-on-error: true
         run: /app/plugin-snyk-sast-scanner -mode single
 
@@ -182,6 +181,7 @@ jobs:
           RUN_ID: ${{ cloudbees.run_id }}
           JOB_ID: ${{ job.id }}
           STEP_ID: ${{ step.internal.id }}
+          CLOUDBEES_SUPPRESS_LOGS: ${{ vars['edgeRedactionSuppressCodeScannerLogs'] || 'false' }}
         continue-on-error: true
         run: /app/plugin-snyk-iac-scanner -mode single
 
@@ -204,6 +204,7 @@ jobs:
           RUN_ID: ${{ cloudbees.run_id }}
           JOB_ID: ${{ job.id }}
           STEP_ID: ${{ step.internal.id }}
+          CLOUDBEES_SUPPRESS_LOGS: ${{ vars['edgeRedactionSuppressCodeScannerLogs'] || 'false' }}
         continue-on-error: true
         run: /app/plugin-checkmarxone-sast-scanner -mode single
 
@@ -215,6 +216,7 @@ jobs:
           RUN_ID: ${{ cloudbees.run_id }}
           JOB_ID: ${{ job.id }}
           STEP_ID: ${{ step.internal.id }}
+          CLOUDBEES_SUPPRESS_LOGS: ${{ vars['edgeRedactionSuppressCodeScannerLogs'] || 'false' }}
         continue-on-error: true
         run: /app/plugin-klocwork-scanner -mode single
 
@@ -227,6 +229,7 @@ jobs:
           RUN_ID: ${{ cloudbees.run_id }}
           JOB_ID: ${{ job.id }}
           STEP_ID: ${{ step.internal.id }}
+          CLOUDBEES_SUPPRESS_LOGS: ${{ vars['edgeRedactionSuppressCodeScannerLogs'] || 'false' }}
         continue-on-error: true
         run: /app/plugin-sonarqube-scanner -mode single
 

--- a/.cloudbees/scanners/code_scan_edge.yaml
+++ b/.cloudbees/scanners/code_scan_edge.yaml
@@ -11,6 +11,12 @@ jobs:
     # condition. Cloud scans (code_scan.yaml) omit this and keep using /reserved/v1.
     env:
       EDGE_SCAN_RUN: "true"
+      # Carries the org's edge-redaction decision (CBP-46176) to transform time. The
+      # edge transformer reads this job env and, when "true", appends --suppress-logs
+      # to code-scanner steps so their stdout/stderr (which can quote matched source)
+      # is drained but never uploaded to the cloud (CBP-46173). The value comes from
+      # the org-scoped property edgeRedactionSuppressCodeScannerLogs.
+      EDGE_REDACTION_SUPPRESS_CODE_SCANNER_LOGS: ${{ vars.edgeRedactionSuppressCodeScannerLogs }}
     steps:
       - name: Initiate execution plan
         uses: https://github.com/cloudbees-io/asset-chain-utils/start-chain@v1

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,9 @@
+# CLAUDE.md
+
+## Git Commit & PR Rules
+
+- **Do NOT add `Co-Authored-By: Claude` (or any AI co-author trailer) to commit messages.**
+- **Do NOT add "🤖 Generated with Claude Code" or similar AI attribution to commits or PR descriptions.**
+- Keep commit messages and PR bodies human-authored in tone — no AI tool branding.
+- **Keep PR descriptions minimal** — what changed and why, no filler.
+- **Keep inline comments minimal** — explain *why*, not *what*; no verbose multi-paragraph blocks. Let the code speak.


### PR DESCRIPTION
## What

Adds one job-env var to `code_scan_edge.yaml`:

```yaml
env:
  EDGE_SCAN_RUN: "true"
  EDGE_REDACTION_SUPPRESS_CODE_SCANNER_LOGS: ${{ vars.edgeRedactionSuppressCodeScannerLogs }}
```

## Why

This carries the org's edge-redaction decision to **transform time**. The edge transformer (dsl-engine-cli, companion PR calculi-corp/dsl-engine-cli#804) reads this job env and, when `"true"`, appends `--suppress-logs` to code-scanner steps so their stdout/stderr — which can quote matched source lines — is drained but never uploaded to the cloud (CBP-46173).

The value comes from the org-scoped property `edgeRedactionSuppressCodeScannerLogs` (persisted by CBP-46176). dsl-engine fetches workflow properties for the component and exposes them as `vars`; org-scoped properties merge down to component scope (verified against the live properties API), so this resolves per-org.
