### PR TITLE
feat(CBP-46178): suppress edge scanner logs via plan output

### DIFF
--- a/.cloudbees/scanners/binary_scan_edge.yaml
+++ b/.cloudbees/scanners/binary_scan_edge.yaml
@@ -105,6 +105,11 @@ jobs:
           RUN_ID: ${{ cloudbees.run_id }}
           JOB_ID: ${{ job.id }}
           STEP_ID: ${{ step.internal.id }}
+          # Edge redaction (CBP-46178): suppress this scanner's logs, which can quote
+          # scanned content. Reads the value asset-service puts on the execution plan,
+          # surfaced by start-chain as a plan output (same channel as code_scan_edge).
+          # Index syntax so a missing output resolves to null → "false".
+          CLOUDBEES_SUPPRESS_LOGS: ${{ steps.plan.outputs['EDGE_REDACTION_SUPPRESS_CODE_SCANNER_LOGS'] || 'false' }}
         continue-on-error: true
         run: /app/plugin-trivy-scanner -mode single
 
@@ -115,6 +120,11 @@ jobs:
           RUN_ID: ${{ cloudbees.run_id }}
           JOB_ID: ${{ job.id }}
           STEP_ID: ${{ step.internal.id }}
+          # Edge redaction (CBP-46178): suppress this scanner's logs, which can quote
+          # scanned content. Reads the value asset-service puts on the execution plan,
+          # surfaced by start-chain as a plan output (same channel as code_scan_edge).
+          # Index syntax so a missing output resolves to null → "false".
+          CLOUDBEES_SUPPRESS_LOGS: ${{ steps.plan.outputs['EDGE_REDACTION_SUPPRESS_CODE_SCANNER_LOGS'] || 'false' }}
         continue-on-error: true
         run: /app/plugin-findsecbugs -mode single
 
@@ -125,6 +135,11 @@ jobs:
           RUN_ID: ${{ cloudbees.run_id }}
           JOB_ID: ${{ job.id }}
           STEP_ID: ${{ step.internal.id }}
+          # Edge redaction (CBP-46178): suppress this scanner's logs, which can quote
+          # scanned content. Reads the value asset-service puts on the execution plan,
+          # surfaced by start-chain as a plan output (same channel as code_scan_edge).
+          # Index syntax so a missing output resolves to null → "false".
+          CLOUDBEES_SUPPRESS_LOGS: ${{ steps.plan.outputs['EDGE_REDACTION_SUPPRESS_CODE_SCANNER_LOGS'] || 'false' }}
         continue-on-error: true
         run: /app/plugin-syftbom-analyser -mode single
 
@@ -135,6 +150,11 @@ jobs:
           RUN_ID: ${{ cloudbees.run_id }}
           JOB_ID: ${{ job.id }}
           STEP_ID: ${{ step.internal.id }}
+          # Edge redaction (CBP-46178): suppress this scanner's logs, which can quote
+          # scanned content. Reads the value asset-service puts on the execution plan,
+          # surfaced by start-chain as a plan output (same channel as code_scan_edge).
+          # Index syntax so a missing output resolves to null → "false".
+          CLOUDBEES_SUPPRESS_LOGS: ${{ steps.plan.outputs['EDGE_REDACTION_SUPPRESS_CODE_SCANNER_LOGS'] || 'false' }}
         continue-on-error: true
         run: /app/plugin-grype-scanner -mode single
 

--- a/.cloudbees/scanners/binary_scan_edge.yaml
+++ b/.cloudbees/scanners/binary_scan_edge.yaml
@@ -161,3 +161,7 @@ jobs:
       - name: Complete execution plan
         uses: https://github.com/cloudbees-io/asset-chain-utils/end-chain@v1
         id: process-outputs
+        with:
+          edge-redaction-strip-basedata: ${{ steps.plan.outputs.EDGE_REDACTION_STRIP_BASEDATA }}
+          edge-redaction-sweep-sarif: ${{ steps.plan.outputs.EDGE_REDACTION_SWEEP_SARIF }}
+          edge-redaction-suppress-code-scanner-logs: ${{ steps.plan.outputs.EDGE_REDACTION_SUPPRESS_CODE_SCANNER_LOGS }}

--- a/.cloudbees/scanners/code_scan_edge.yaml
+++ b/.cloudbees/scanners/code_scan_edge.yaml
@@ -262,3 +262,7 @@ jobs:
       - name: Complete execution plan
         uses: https://github.com/cloudbees-io/asset-chain-utils/end-chain@v1
         id: process-outputs
+        with:
+          edge-redaction-strip-basedata: ${{ steps.plan.outputs.EDGE_REDACTION_STRIP_BASEDATA }}
+          edge-redaction-sweep-sarif: ${{ steps.plan.outputs.EDGE_REDACTION_SWEEP_SARIF }}
+          edge-redaction-suppress-code-scanner-logs: ${{ steps.plan.outputs.EDGE_REDACTION_SUPPRESS_CODE_SCANNER_LOGS }}

--- a/.cloudbees/scanners/code_scan_edge.yaml
+++ b/.cloudbees/scanners/code_scan_edge.yaml
@@ -86,6 +86,10 @@ jobs:
           RUN_ID: ${{ cloudbees.run_id }}
           JOB_ID: ${{ job.id }}
           STEP_ID: ${{ step.internal.id }}
+          # Edge redaction (CBP-46178): suppress this code scanner's logs (can quote
+          # matched source). Reads the plan output asset-service emits; index syntax so
+          # a missing output resolves to null → "false" (suppression off).
+          CLOUDBEES_SUPPRESS_LOGS: ${{ steps.plan.outputs['EDGE_REDACTION_SUPPRESS_CODE_SCANNER_LOGS'] || 'false' }}
         continue-on-error: true
         run: /app/plugin-scc-scanner -mode single
 
@@ -96,6 +100,10 @@ jobs:
           RUN_ID: ${{ cloudbees.run_id }}
           JOB_ID: ${{ job.id }}
           STEP_ID: ${{ step.internal.id }}
+          # Edge redaction (CBP-46178): suppress this code scanner's logs (can quote
+          # matched source). Reads the plan output asset-service emits; index syntax so
+          # a missing output resolves to null → "false" (suppression off).
+          CLOUDBEES_SUPPRESS_LOGS: ${{ steps.plan.outputs['EDGE_REDACTION_SUPPRESS_CODE_SCANNER_LOGS'] || 'false' }}
         continue-on-error: true
         run: /app/plugin-gosec-scanner -mode single
 
@@ -106,6 +114,10 @@ jobs:
           RUN_ID: ${{ cloudbees.run_id }}
           JOB_ID: ${{ job.id }}
           STEP_ID: ${{ step.internal.id }}
+          # Edge redaction (CBP-46178): suppress this code scanner's logs (can quote
+          # matched source). Reads the plan output asset-service emits; index syntax so
+          # a missing output resolves to null → "false" (suppression off).
+          CLOUDBEES_SUPPRESS_LOGS: ${{ steps.plan.outputs['EDGE_REDACTION_SUPPRESS_CODE_SCANNER_LOGS'] || 'false' }}
         continue-on-error: true
         run: /app/plugin-njsscan-scanner -mode single
 
@@ -117,6 +129,10 @@ jobs:
           RUN_ID: ${{ cloudbees.run_id }}
           JOB_ID: ${{ job.id }}
           STEP_ID: ${{ step.internal.id }}
+          # Edge redaction (CBP-46178): suppress this code scanner's logs (can quote
+          # matched source). Reads the plan output asset-service emits; index syntax so
+          # a missing output resolves to null → "false" (suppression off).
+          CLOUDBEES_SUPPRESS_LOGS: ${{ steps.plan.outputs['EDGE_REDACTION_SUPPRESS_CODE_SCANNER_LOGS'] || 'false' }}
         run: /app/plugin-gitleaks-scanner -mode single
 
       - name: BlackDuck Scanner
@@ -148,6 +164,10 @@ jobs:
           RUN_ID: ${{ cloudbees.run_id }}
           JOB_ID: ${{ job.id }}
           STEP_ID: ${{ step.internal.id }}
+          # Edge redaction (CBP-46178): suppress this code scanner's logs (can quote
+          # matched source). Reads the plan output asset-service emits; index syntax so
+          # a missing output resolves to null → "false" (suppression off).
+          CLOUDBEES_SUPPRESS_LOGS: ${{ steps.plan.outputs['EDGE_REDACTION_SUPPRESS_CODE_SCANNER_LOGS'] || 'false' }}
         continue-on-error: true
         run: /app/plugin-checkov -mode single
 
@@ -159,6 +179,10 @@ jobs:
           RUN_ID: ${{ cloudbees.run_id }}
           JOB_ID: ${{ job.id }}
           STEP_ID: ${{ step.internal.id }}
+          # Edge redaction (CBP-46178): suppress this code scanner's logs (can quote
+          # matched source). Reads the plan output asset-service emits; index syntax so
+          # a missing output resolves to null → "false" (suppression off).
+          CLOUDBEES_SUPPRESS_LOGS: ${{ steps.plan.outputs['EDGE_REDACTION_SUPPRESS_CODE_SCANNER_LOGS'] || 'false' }}
         continue-on-error: true
         run: /app/plugin-snyk-sast-scanner -mode single
 
@@ -170,6 +194,10 @@ jobs:
           RUN_ID: ${{ cloudbees.run_id }}
           JOB_ID: ${{ job.id }}
           STEP_ID: ${{ step.internal.id }}
+          # Edge redaction (CBP-46178): suppress this code scanner's logs (can quote
+          # matched source). Reads the plan output asset-service emits; index syntax so
+          # a missing output resolves to null → "false" (suppression off).
+          CLOUDBEES_SUPPRESS_LOGS: ${{ steps.plan.outputs['EDGE_REDACTION_SUPPRESS_CODE_SCANNER_LOGS'] || 'false' }}
         continue-on-error: true
         run: /app/plugin-snyk-iac-scanner -mode single
 
@@ -192,6 +220,10 @@ jobs:
           RUN_ID: ${{ cloudbees.run_id }}
           JOB_ID: ${{ job.id }}
           STEP_ID: ${{ step.internal.id }}
+          # Edge redaction (CBP-46178): suppress this code scanner's logs (can quote
+          # matched source). Reads the plan output asset-service emits; index syntax so
+          # a missing output resolves to null → "false" (suppression off).
+          CLOUDBEES_SUPPRESS_LOGS: ${{ steps.plan.outputs['EDGE_REDACTION_SUPPRESS_CODE_SCANNER_LOGS'] || 'false' }}
         continue-on-error: true
         run: /app/plugin-checkmarxone-sast-scanner -mode single
 
@@ -203,6 +235,10 @@ jobs:
           RUN_ID: ${{ cloudbees.run_id }}
           JOB_ID: ${{ job.id }}
           STEP_ID: ${{ step.internal.id }}
+          # Edge redaction (CBP-46178): suppress this code scanner's logs (can quote
+          # matched source). Reads the plan output asset-service emits; index syntax so
+          # a missing output resolves to null → "false" (suppression off).
+          CLOUDBEES_SUPPRESS_LOGS: ${{ steps.plan.outputs['EDGE_REDACTION_SUPPRESS_CODE_SCANNER_LOGS'] || 'false' }}
         continue-on-error: true
         run: /app/plugin-klocwork-scanner -mode single
 
@@ -215,6 +251,10 @@ jobs:
           RUN_ID: ${{ cloudbees.run_id }}
           JOB_ID: ${{ job.id }}
           STEP_ID: ${{ step.internal.id }}
+          # Edge redaction (CBP-46178): suppress this code scanner's logs (can quote
+          # matched source). Reads the plan output asset-service emits; index syntax so
+          # a missing output resolves to null → "false" (suppression off).
+          CLOUDBEES_SUPPRESS_LOGS: ${{ steps.plan.outputs['EDGE_REDACTION_SUPPRESS_CODE_SCANNER_LOGS'] || 'false' }}
         continue-on-error: true
         run: /app/plugin-sonarqube-scanner -mode single
 


### PR DESCRIPTION
## What
Wire `CLOUDBEES_SUPPRESS_LOGS` on the edge scan workflows from the execution-plan output `EDGE_REDACTION_SUPPRESS_CODE_SCANNER_LOGS` that asset-service emits.
- **code_scan_edge**: the 10 SAST/secret scanners (SCC, GoSec, Njs, Gitleaks, Checkov, Snyk SAST, Snyk IaC, Checkmarxone SAST, Perforce Klocwork, Sonar). BlackDuck, Coverity, Snyk SCA excluded (SCA/proprietary, no raw source).
- **binary_scan_edge**: Trivy, FindSecBugs, Syft, Grype.

## Why
On `main` neither edge workflow had working suppression: `code_scan_edge` had **no** wiring, and an earlier unmerged attempt sourced the value from `vars['edgeRedactionSuppressCodeScannerLogs']` — a workflow-variable channel that **asset-service never populates** (the value is only emitted onto the execution plan). So scanner stdout that can quote scanned source/content streamed to the cloud on edge runs regardless of the org's edge-redaction config.

## Mechanism
Uses the same proven channel as `compliance-workflows-preprod` (and as `steps.plan.outputs.account_credentials` already used here): asset-service puts the flag on the plan, start-chain surfaces it as a plan output, the scanner step reads it via index syntax (missing → `false`), dsl-engine drains that step's stdout at runtime.

## Not included (tracked separately)
The end-chain run-level 'logs retained on-premise' notice is **not** wired here: the prod `asset-chain-utils/end-chain` action does not yet declare the `edge-redaction-*` inputs (they exist only in `asset-chain-utils-preprod`). Scanner-step suppression above needs no action change. Follow-up: port the end-chain inputs + `assets-plugin-chain-utils` image bump to prod `asset-chain-utils`.

## Test
- YAML validated, no tabs; code_scan_edge 10 suppress lines, binary_scan_edge 4.
- Verify: edge scan on an org with `suppressCodeScannerLogs=true` → scanner stdout absent from the cloud log.