### PR TITLE
feat(SECO-5688): Update Klocwork Scanner Version Commit

### DIFF
--- a/.cloudbees/scanners/code_scan.yaml
+++ b/.cloudbees/scanners/code_scan.yaml
@@ -192,7 +192,7 @@ jobs:
 
       - name: Perforce Klocwork Scanner
         if: ${{ steps.plan.outputs.perforce-klocwork-sast == 'true' }}
-        uses: docker://public.ecr.aws/l7o7z1g8/actions/assets-klocwork-scanner:a4ec7ead705ee92b068b55daa2bab2f3e82a044b
+        uses: docker://public.ecr.aws/l7o7z1g8/actions/assets-klocwork-scanner:3773435041acff15ea0d55d0700e8018e9cb09c9
         env:
           KLOCWORK_PROPS: ${{ steps.plan.outputs.perforce-klocwork-sast-props}}
           RUN_ID: ${{ cloudbees.run_id }}

--- a/.cloudbees/scanners/code_scan_edge.yaml
+++ b/.cloudbees/scanners/code_scan_edge.yaml
@@ -274,7 +274,7 @@ jobs:
 
       - name: Perforce Klocwork Scanner
         if: ${{ steps.plan.outputs.perforce-klocwork-sast == 'true' }}
-        uses: docker://public.ecr.aws/l7o7z1g8/actions/assets-klocwork-scanner:a4ec7ead705ee92b068b55daa2bab2f3e82a044b
+        uses: docker://public.ecr.aws/l7o7z1g8/actions/assets-klocwork-scanner:3773435041acff15ea0d55d0700e8018e9cb09c9
         env:
           KLOCWORK_PROPS: ${{ steps.plan.outputs.perforce-klocwork-sast-props}}
           RUN_ID: ${{ cloudbees.run_id }}


### PR DESCRIPTION
This pull request updates the Perforce Klocwork Scanner Docker image version in both the main and edge code scan workflows. The update ensures that both workflows use the latest scanner image for improved consistency and potential bug fixes.

Dependency update:

* Updated the Perforce Klocwork Scanner Docker image version from `a4ec7ead705ee92b068b55daa2bab2f3e82a044b` to `3773435041acff15ea0d55d0700e8018e9cb09c9` in `.cloudbees/scanners/code_scan.yaml` and `.cloudbees/scanners/code_scan_edge.yaml`. [[1]](diffhunk://#diff-e2e49cf2219269a32191eea81c0359256c30af94d865e7a82f810354f735f192L195-R195) [[2]](diffhunk://#diff-0997657e94862c67029e088cda39597a630f44b18dbace633640b67884c2c7a5L277-R277)